### PR TITLE
add license to data/cmf/cmf_1931.json

### DIFF
--- a/data/cmf/cmf_1931.json
+++ b/data/cmf/cmf_1931.json
@@ -8,7 +8,7 @@
         "measurement_equipment"  : null,
         "laboratory"             : "scitech",
         "document_creation_date" : "2017-04-16T12:00:00Z",
-        "comments"               : "adapted from the data available under 'CC-BY-4.0' from CIE at https://cie.co.at/datatable/cie-1931-chromaticity-coordinates-spectrum-loci-2-degree-observer",
+        "comments"               : "CIE 2019, Colour-matching functions of CIE 1931 standard colorimetric observer, International Commission on Illumination (CIE), Vienna, AT, DOI: 10.25039/CIE.DS.xvudnb9b",
         "license"                : "CC-BY-4.0"
     },
     "spectral_data": {


### PR DESCRIPTION
As discussed, I've added the "CC-BY-4.0" in the `header/license` attribute of the CIE1931 file, and put the link to the source data in the `header/comment` attribute.